### PR TITLE
Alonzo upgrade compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 - cardano-node / cardano-cli set up on local machine (https://docs.cardano.org/projects/cardano-node/en/latest)
 - Node.js installed version 14
-- cardano-cli-js package installed 
+- cardano-cli-js package installed
 - cardano-minter repo from the previous tutorial
 
 **If you haven't already, watch the previous video tutorial here:**
@@ -16,7 +16,15 @@ cd cardano-minter
 ```
 ## Install additional dependencies
 ```bash
-npm install form-data dotenv axios lodash sharp promise-parallel-throttle --save
+npm install form-data dotenv axios lodash sharp promise-parallel-throttle prompt-sync --save
+```
+
+After that, make sure to use the newest cardanocli-js repo by directly cloning it
+into the modules folder with the command:
+```
+git clone https://github.com/Berry-Pool/cardanocli-js.git temp_mod
+cp -r temp_mod/* node_modules/cardanocli-js/
+rm -rf temp_mod
 ```
 # Tutorial Overview
 
@@ -49,7 +57,7 @@ node src/generate-thumbnails.js
 - iterate over each item in metadata.json and:
     - pin the original image to ipfs
     - pin the thumbnail to ipfs
-    - store the reference to both src and image on ipfs in metadata.json 
+    - store the reference to both src and image on ipfs in metadata.json
 - create pin-images-to-ipfs.js
 ```bash
 node src/pin-to-ipfs.js
@@ -60,7 +68,7 @@ node src/pin-images-to-ipfs.js
 
 ## Before you mint transaction
 
-- Speak about the various minting policies. https://docs.cardano.org/projects/cardano-node/en/latest/reference/simple-scripts.html#Step-1---construct-the-tx-body 
+- Speak about the various minting policies. https://docs.cardano.org/projects/cardano-node/en/latest/reference/simple-scripts.html#Step-1---construct-the-tx-body
 
 ## 7. Create an "open" or "unlocked" minting policy and script
 - We will create a open minting policy script and export it in a JSON and TXT format.
@@ -80,7 +88,7 @@ node src/create-time-locked-mint-policy.js
 node src/get-policy-id.js
 ```
 
-## 9. Define the mint transaction 
+## 9. Define the mint transaction
 1. build mint transaction with metadata.json
 2. calc fee
 3. rebuild
@@ -94,4 +102,9 @@ node src/mint-multiple-assets.js
 -Make a script to send multiple assets back to a wallet in a single transaction.
 ```bash
 node src/send-multiple-assets-back-to-wallet.js
+
+## Optional: Burn all assets
+If you recognize errors in the metadata and want to mint again, use:
+```bash node src/burn-all-assets.js
 ```
+**WARNING: All assets will be burned. Use with caution.**

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ node src/mint-multiple-assets.js
 -Make a script to send multiple assets back to a wallet in a single transaction.
 ```bash
 node src/send-multiple-assets-back-to-wallet.js
-
-## Optional: Burn all assets
-If you recognize errors in the metadata and want to mint again, use:
-```bash node src/burn-all-assets.js
 ```
-**WARNING: All assets will be burned. Use with caution.**
+## Optional: Burn all assets
+If there are any errors with the metadata, this script is able to burn the entire wallet content:
+
+```bash node src/burn-all-assets.js```
+
+**WARNING:** All assets will be burned. Use with caution.

--- a/src/burn-all-assets.js
+++ b/src/burn-all-assets.js
@@ -1,0 +1,78 @@
+const cardano = require("./cardano")
+const getPolicyId = require("./get-policy-id")
+const prompt = require('prompt-sync')({sigint: true});
+
+// This script will burn all assets in the Wallet specifed below. Good for minting errors. Use with Caution!
+
+const wallet = cardano.wallet("ADAPI")
+
+const { policyId: POLICY_ID, mintScript } = getPolicyId()
+
+const wallet_assets = {
+   ...wallet.balance().value,
+}
+for (const [key, value] of Object.entries(wallet_assets)) {
+  if (key == 'lovelace') {
+    delete wallet_assets[key]
+  }
+}
+const wallet_assets_keys = Object.keys(wallet_assets)
+
+
+const txOut_value = {
+   ...wallet.balance().value,
+}
+for (const [key, value] of Object.entries(txOut_value)) {
+  if (key != 'lovelace') {
+    txOut_value[key] = 0
+  }
+}
+console.log("The following Assets will be burned: ", wallet_assets_keys)
+
+const mint_actions = wallet_assets_keys.map(asset => ({ action: "mint", quantity: -1, asset: asset, script: mintScript }))
+
+
+const tx = {
+    txIn: wallet.balance().utxo,
+    txOut: [
+        {
+            address: wallet.paymentAddr,
+            value: txOut_value
+        }
+    ],
+    mint: mint_actions,
+    witnessCount: 2
+}
+
+const buildTransaction = (tx) => {
+
+    const raw = cardano.transactionBuildRaw(tx)
+    const fee = cardano.transactionCalculateMinFee({
+        ...tx,
+        txBody: raw
+    })
+
+    tx.txOut[0].value.lovelace -= fee
+
+    return cardano.transactionBuildRaw({ ...tx, fee })
+}
+prompt("Are you sure to burn all tokens ?")
+const raw = buildTransaction(tx)
+
+// 9. Sign transaction
+
+const signTransaction = (wallet, tx) => {
+
+    return cardano.transactionSign({
+        signingKeys: [wallet.payment.skey, wallet.payment.skey],
+        txBody: tx
+    })
+}
+
+const signed = signTransaction(wallet, raw, mintScript)
+
+// 10. Submit transaction
+prompt("Are you really sure? No going back!")
+const txHash = cardano.transactionSubmit(signed)
+
+console.log(txHash)

--- a/src/mint-multiple-assets.js
+++ b/src/mint-multiple-assets.js
@@ -41,7 +41,7 @@ const txOut_value = assets.reduce((result, asset) => {
     ...wallet.balance().value
 })
 
-const mint_actions = assets.map(asset => ({ type: "mint", quantity: 1, asset: POLICY_ID + "." + asset.id }))
+const mint_actions = assets.map(asset => ({ action: "mint", quantity: 1, asset: POLICY_ID + "." + asset.id, script: mintScript }))
 
 const tx = {
     txIn: wallet.balance().utxo,
@@ -51,13 +51,16 @@ const tx = {
             value: txOut_value
         }
     ],
-    mint: {
-        actions: mint_actions,
-        script: [mintScript]
-    },
+    mint: mint_actions,
     metadata,
     witnessCount: 2
 }
+
+// Remove the undefined from the transaction if it extists
+if(Object.keys(tx.txOut[0].value).includes("undefined")){
+  delete tx.txOut[0].value.undefined
+}
+
 
 const buildTransaction = (tx) => {
 


### PR DESCRIPTION
Updated the minter to make sure it works with cardano node version 
v1.30.1

- fixed minting.acions.ForEach error
- added burn script for all assets
- updated readme (get newest cardanocli-js version, burn-all-assets.js 
description)

Tested with cardano-node v1.30.1 on the mainnet. 

